### PR TITLE
modified build process to allow docker volume to point just to `/config/www/workspace`

### DIFF
--- a/root/etc/cont-init.d/50-install
+++ b/root/etc/cont-init.d/50-install
@@ -46,3 +46,8 @@ cp -a /config/build/* /config/www/
 # permissions
 chown -R abc:abc \
         /config
+
+# fix temporary error in upstream codiad use of mb_ord()
+# https://github.com/Codiad/Codiad/issues/1082
+cd /config/www/lib
+sed -i 's!\(mb_ord\)!codiad_\1!g;s!\(mb_chr\)!codiad_\1!g' diff_match_patch.php

--- a/root/etc/cont-init.d/50-install
+++ b/root/etc/cont-init.d/50-install
@@ -2,39 +2,47 @@
 
 # make our folders
 mkdir -p \
-	/config/projects
+        /config/projects
+
+# make temporary build folder
+# we will then move files into place (or else we end up with problems overwriting our mapped project dir)
+mkdir -p \
+        /config/build
 
 # install codiad and plugins
-if [ ! -d "/config/www/.git" ]; then
-	rm -rf /config/www/*
-	git clone https://github.com/Codiad/Codiad /config/www
-	[[ -e /config/www/config.php ]] && rm /config/www/config.php
+if [ ! -d "/config/build/.git" ]; then
+        rm -rf /config/build/*
+        git clone https://github.com/Codiad/Codiad /config/build
+        [[ -e /config/build/config.php ]] && rm /config/build/config.php
 fi
 
-[[ ! -d "/config/www/plugins/Codiad-Collaborative-master/.git" ]] && \
-	git clone https://github.com/Codiad/Codiad-Collaborative \
-	/config/www/plugins/Codiad-Collaborative-master/
+[[ ! -d "/config/build/plugins/Codiad-Collaborative-master/.git" ]] && \
+        git clone https://github.com/Codiad/Codiad-Collaborative \
+        /config/build/plugins/Codiad-Collaborative-master/
 
-[[ ! -d "/config/www/plugins/Codiad-CodeGit-master/.git" ]] && \
-	git clone https://github.com/Andr3as/Codiad-CodeGit \
-	/config/www/plugins/Codiad-CodeGit-master/
+[[ ! -d "/config/build/plugins/Codiad-CodeGit-master/.git" ]] && \
+        git clone https://github.com/Andr3as/Codiad-CodeGit \
+        /config/build/plugins/Codiad-CodeGit-master/
 
-[[ ! -d "/config/www/plugins/Codiad-DragDrop-master/.git" ]] && \
-	git clone https://github.com/Andr3as/Codiad-DragDrop \
-	/config/www/plugins/Codiad-DragDrop-master/
+[[ ! -d "/config/build/plugins/Codiad-DragDrop-master/.git" ]] && \
+        git clone https://github.com/Andr3as/Codiad-DragDrop \
+        /config/build/plugins/Codiad-DragDrop-master/
 
-[[ ! -d "/config/www/plugins/Codiad-Terminal-master/.git" ]] && \
-	git clone https://github.com/Fluidbyte/Codiad-Terminal \
-	/config/www/plugins/Codiad-Terminal-master/
+[[ ! -d "/config/build/plugins/Codiad-Terminal-master/.git" ]] && \
+        git clone https://github.com/Fluidbyte/Codiad-Terminal \
+        /config/build/plugins/Codiad-Terminal-master/
 
 # copy config
-[[ ! -e /config/www/config.php ]] && \
-	cp /defaults/config.php /config/www/config.php
+[[ ! -e /config/build/config.php ]] && \
+        cp /defaults/config.php /config/build/config.php
 
 # fix collaboration error
 sed -i s/' echo formatJSEND("error","Warning: File ".'/'#echo formatJSEND("error","Warning: File ".'/ \
-	/config/www/components/active/class.active.php
+        /config/build/components/active/class.active.php
+
+# copy build files to active directory (should not override workspace files - apart from "README")
+cp -a /config/build/* /config/www/
 
 # permissions
 chown -R abc:abc \
-	/config
+        /config


### PR DESCRIPTION
<!--- The major change here is that building codiad now happens in a separate directory before copying to the `www` dir.  This enables the workspace directory to already be populated -->

addresses https://github.com/linuxserver/docker-codiad/issues/14

