### PR TITLE
deprecate image

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Find us at:
 [![Build Status](https://ci.linuxserver.io/buildStatus/icon?job=Docker-Pipeline-Builders/docker-codiad/master)](https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-codiad/job/master/)
 [![](https://lsio-ci.ams3.digitaloceanspaces.com/linuxserver/codiad/latest/badge.svg)](https://lsio-ci.ams3.digitaloceanspaces.com/linuxserver/codiad/latest/index.html)
 
-[Codiad](http://codiad.com/) is a web-based IDE framework with a small footprint and minimal requirements. We have added a few plugins. More can be added in the marketplace in the WebUI.
+THIS IMAGE IS DEPRECATED. PLEASE MIGRATE TO CLOUD9 IF POSSIBLE `linuxserver/cloud9` [Codiad](http://codiad.com/) is a web-based IDE framework with a small footprint and minimal requirements. We have added a few plugins. More can be added in the marketplace in the WebUI.
 
 [![codiad](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/codiad.png)](http://codiad.com/)
 
@@ -172,6 +172,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **10.06.19:** - Deprecate Image.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.
 * **22.02.19:** - Rebasing to alpine 3.9, adding ssh client.
 * **16.01.19:** - Add pipeline logic and multi arch.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -4,7 +4,7 @@
 project_name: codiad
 project_url: "http://codiad.com/"
 project_logo: "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/codiad.png"
-project_blurb: "[{{ project_name|capitalize }}]({{ project_url }}) is a web-based IDE framework with a small footprint and minimal requirements. We have added a few plugins. More can be added in the marketplace in the WebUI."
+project_blurb: "THIS IMAGE IS DEPRECATED. PLEASE MIGRATE TO CLOUD9 IF POSSIBLE `linuxserver/cloud9` [{{ project_name|capitalize }}]({{ project_url }}) is a web-based IDE framework with a small footprint and minimal requirements. We have added a few plugins. More can be added in the marketplace in the WebUI."
 project_lsio_github_repo_url: "https://github.com/linuxserver/docker-{{ project_name }}"
 project_blurb_optional_extras_enabled: false
 
@@ -46,6 +46,7 @@ app_setup_block_enabled: false
 
 # changelog
 changelogs:
+  - { date: "10.06.19:", desc: "Deprecate Image." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "22.02.19:", desc: "Rebasing to alpine 3.9, adding ssh client." }
   - { date: "16.01.19:", desc: "Add pipeline logic and multi arch." }

--- a/root/etc/cont-init.d/90-config
+++ b/root/etc/cont-init.d/90-config
@@ -1,0 +1,21 @@
+#!/usr/bin/with-contenv bash
+
+echo '
+******************************************************
+******************************************************
+*                                                    *
+*                                                    *
+*          This image has been deprecated            *
+*                                                    *
+*    It will no longer recieve security updates      *
+*                                                    *
+*       We reccomend Cloud9 as a replacement         *
+*                                                    *
+*    https://hub.docker.com/r/linuxserver/cloud9     *
+*                                                    *
+*    https://github.com/linuxserver/docker-cloud9    *
+*                                                    *
+*                                                    *
+*                                                    *
+******************************************************
+******************************************************'


### PR DESCRIPTION
Title. upstream is basically dead and we now have a viable alternative to this image with Cloud9. We will no longer build this image.